### PR TITLE
Change gh-corner octoColor to match Hero background

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -34,7 +34,7 @@ ReactDOM.render(
     <GithubCorner
       href={`https://github.com/${project}`}
       bannerColor="#fff"
-      octoColor="#000"
+      octoColor="#003b5c"
       width={80}
       height={80}
       direction="right"


### PR DESCRIPTION
Little detail to take advantage of `gh-corner` available props to match the style of the demo.

<img width="1083" alt="screen shot 2017-10-23 at 14 49 02" src="https://user-images.githubusercontent.com/784056/31889812-5e97829e-b801-11e7-835f-cd06cf19c40d.png">
